### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 override SRCDIR := src
 override BUILDDIR := build
+override UTILS_DIR := utils
 override TARGET = $(BUILDDIR)/shimeji-overlayd
 
 override CFLAGS  += -I$(SRCDIR) -I$(BUILDDIR) -O2 -Wall -Wextra -fno-strict-aliasing
@@ -87,8 +88,9 @@ PREFIX ?= /usr/local
 
 .PHONY: install
 install: $(TARGET)
-	install -Dm755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
-	install -Dm755 $(UTILS_DIR)/shimejictl $(DESTDIR)$(PREFIX)/bin/shimejictl
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install -m755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/
+	install -m755 $(UTILS_DIR)/shimejictl $(DESTDIR)$(PREFIX)/bin/shimejictl
 
 # Handle header dependency rebuild
 sinclude $(DEPS)


### PR DESCRIPTION
Fixes https://github.com/CluelessCatBurger/wl_shimeji/issues/1

Tested building with the following `default.nix`. I can commit it if you want.

```nix
{ pkgs ? import <nixpkgs> {} }:

with pkgs;

stdenv.mkDerivation {
  name = "wl_shimeji";
  src = ./.;

  nativeBuildInputs = [
    pkg-config
  ];

  makeFlags = [
    "PREFIX=$(out)"
  ];

  buildInputs = [
    libspng
    python3
    wayland
    wayland-protocols
    wayland-scanner
    wlr-protocols
  ];
}
```