### PR TITLE
Support for multi-monitor setups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ override WL_HEADERS := \
 	$(WL_PROTO_DIR)/tablet-v2.h \
 	$(WL_PROTO_DIR)/xdg-shell.h \
 	$(WL_PROTO_DIR)/fractional-scale-v1.h \
-	$(WL_PROTO_DIR)/wlr-layer-shell.h
+	$(WL_PROTO_DIR)/wlr-layer-shell.h \
+	$(WL_PROTO_DIR)/xdg-output.h
 
 override SRC := \
 	$(wildcard $(SRCDIR)/*.c) \
@@ -67,6 +68,8 @@ $(WL_PROTO_DIR)/%.h:
 	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml                   $(WL_PROTO_DIR)/xdg-shell.c
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/staging/fractional-scale/fractional-scale-v1.xml $(WL_PROTO_DIR)/fractional-scale-v1.h
 	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/staging/fractional-scale/fractional-scale-v1.xml $(WL_PROTO_DIR)/fractional-scale-v1.c
+	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml       $(WL_PROTO_DIR)/xdg-output.h
+	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml       $(WL_PROTO_DIR)/xdg-output.c
 	$(WAYLAND_SCANNER) client-header $(WLR_PROTOCOLS_DIR)/unstable/wlr-layer-shell-unstable-v1.xml             $(WL_PROTO_DIR)/wlr-layer-shell.h
 	$(WAYLAND_SCANNER) private-code  $(WLR_PROTOCOLS_DIR)/unstable/wlr-layer-shell-unstable-v1.xml             $(WL_PROTO_DIR)/wlr-layer-shell.c
 

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ $(WL_PROTO_DIR)/protocols.d:
 	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml                   $(WL_PROTO_DIR)/xdg-shell.c
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/staging/fractional-scale/fractional-scale-v1.xml $(WL_PROTO_DIR)/fractional-scale-v1.h
 	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/staging/fractional-scale/fractional-scale-v1.xml $(WL_PROTO_DIR)/fractional-scale-v1.c
-	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml       $(WL_PROTO_DIR)/xdg-output.h
-	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml
+	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml   $(WL_PROTO_DIR)/xdg-output.h
+	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml   $(WL_PROTO_DIR)/xdg-output.c
 	$(WAYLAND_SCANNER) client-header $(WLR_PROTOCOLS_DIR)/unstable/wlr-layer-shell-unstable-v1.xml             $(WL_PROTO_DIR)/wlr-layer-shell.h
 	$(WAYLAND_SCANNER) private-code  $(WLR_PROTOCOLS_DIR)/unstable/wlr-layer-shell-unstable-v1.xml             $(WL_PROTO_DIR)/wlr-layer-shell.c
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ override WL_HEADERS := \
 	$(WL_PROTO_DIR)/tablet-v2.h \
 	$(WL_PROTO_DIR)/xdg-shell.h \
 	$(WL_PROTO_DIR)/fractional-scale-v1.h \
-	$(WL_PROTO_DIR)/wlr-layer-shell.h
+	$(WL_PROTO_DIR)/wlr-layer-shell.h \
+	$(WL_PROTO_DIR)/xdg-output.h
 
 override SRC := \
 	$(wildcard $(SRCDIR)/*.c) \

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ override WL_HEADERS := \
 	$(WL_PROTO_DIR)/tablet-v2.h \
 	$(WL_PROTO_DIR)/xdg-shell.h \
 	$(WL_PROTO_DIR)/fractional-scale-v1.h \
-	$(WL_PROTO_DIR)/wlr-layer-shell.h \
-	$(WL_PROTO_DIR)/xdg-output.h
+	$(WL_PROTO_DIR)/wlr-layer-shell.h
 
 override SRC := \
 	$(wildcard $(SRCDIR)/*.c) \
@@ -57,7 +56,7 @@ override _ := $(shell mkdir -p $(DIRS))
 	@:
 
 # Generate wayland-protocols headers & sources
-$(WL_PROTO_DIR)/%.h:
+$(WL_PROTO_DIR)/protocols.d:
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/staging/cursor-shape/cursor-shape-v1.xml         $(WL_PROTO_DIR)/cursor-shape-v1.h
 	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/staging/cursor-shape/cursor-shape-v1.xml         $(WL_PROTO_DIR)/cursor-shape-v1.c
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/stable/viewporter/viewporter.xml                 $(WL_PROTO_DIR)/viewporter.h
@@ -69,33 +68,33 @@ $(WL_PROTO_DIR)/%.h:
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/staging/fractional-scale/fractional-scale-v1.xml $(WL_PROTO_DIR)/fractional-scale-v1.h
 	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/staging/fractional-scale/fractional-scale-v1.xml $(WL_PROTO_DIR)/fractional-scale-v1.c
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml       $(WL_PROTO_DIR)/xdg-output.h
-	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml       $(WL_PROTO_DIR)/xdg-output.c
+	$(WAYLAND_SCANNER) private-code  $(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-output/xdg-output-unstable-v1.xml
 	$(WAYLAND_SCANNER) client-header $(WLR_PROTOCOLS_DIR)/unstable/wlr-layer-shell-unstable-v1.xml             $(WL_PROTO_DIR)/wlr-layer-shell.h
 	$(WAYLAND_SCANNER) private-code  $(WLR_PROTOCOLS_DIR)/unstable/wlr-layer-shell-unstable-v1.xml             $(WL_PROTO_DIR)/wlr-layer-shell.c
 
-# Rule to build wayland-protocol sources
-$(WL_PROTO_DIR)/%.o: $(WL_PROTO_DIR)/%.c Makefile
-	$(CC) $(CFLAGS) -MMD -MF $(patsubst %.o, %.d, $@) -c $< -o $@
+# # Rule to build wayland-protocol sources
+# $(WL_PROTO_DIR)/%.o: $(WL_PROTO_DIR)/%.c Makefile
+# 	$(CC) $(CFLAGS) -MMD -MF $(patsubst %.o, %.d, $@) -c $< -o $@
 
 # Rule to build generic source files
-$(BUILDDIR)/%.o: $(SRCDIR)/%.c $(WL_HEADERS) Makefile
+$(BUILDDIR)/%.o: $(SRCDIR)/%.c $(WL_PROTO_DIR)/protocols.d Makefile
 	$(CC) $(CFLAGS) -MMD -MF $(patsubst %.o, %.d, $@) -c $< -o $@
 
-$(PLUGINS_TARGET): $(PLUGINS_OBJS)
+$(PLUGINS_TARGET): $(PLUGINS_OBJS) $(WL_PROTO_DIR)/protocols.d
 	$(CC) $(PLUGINS_SRC) -DPLUGINSUPPORT_IMPLEMENTATION -I$(BUILDDIR) -fPIC -shared -lm -o $(PLUGINS_TARGET)
 
 # Rule to build the binary
 $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
 
+.NOTPARALLEL: $(WL_HEADERS)
+
 .PHONY: all
 all: $(TARGET) $(PLUGINS_TARGET)
 
 .PHONY: clean
 clean:
-	@-rm -r $(BUILDDIR) $(TARGET)
-
-.NOTPARALLEL: $(WL_PROTO_DIR)/%.o
+	@-rm -r $(TARGET) $(PLUGINS_TARGET) $(BUILDDIR)
 
 .PHONY: install
 install: $(TARGET) $(PLUGINS_TARGET)
@@ -107,3 +106,5 @@ install: $(TARGET) $(PLUGINS_TARGET)
 
 # Handle header dependency rebuild
 sinclude $(DEPS)
+
+.DEFAULT_GOAL := all

--- a/src/config.c
+++ b/src/config.c
@@ -1,3 +1,22 @@
+/*
+    config.c - wl_shimeji's config file parser
+
+    Copyright (C) 2025  CluelessCatBurger <github.com/CluelessCatBurger>
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "config.h"
 
 #include <stdio.h>
@@ -47,6 +66,8 @@ bool config_parse(const char* path)
             config_set_per_mascot_interactions(strncmp(value, "true", 4) == 0);
         } else if (strcmp(key, "tick_delay") == 0) {
             config_set_tick_delay(atoi(value));
+        } else if (strcmp(key, "overlay_layer") == 0) {
+            config_set_overlay_layer(atoi(value));
         }
     }
 
@@ -71,6 +92,7 @@ void config_write(const char* path)
     fprintf(file, "allow_dismiss_animations=%s\n", config.dismiss_animations ? "true" : "false");
     fprintf(file, "per_mascot_interactions=%s\n", config.affordances ? "true" : "false");
     fprintf(file, "tick_delay=%u\n", config.tick_delay);
+    fprintf(file, "overlay_layer=%d\n", config.overlay_layer);
 
     fclose(file);
 }
@@ -139,6 +161,12 @@ bool config_set_tick_delay(uint32_t value)
     return true;
 }
 
+bool config_set_overlay_layer(int32_t value)
+{
+    config.overlay_layer = value;
+    return true;
+}
+
 bool config_get_breeding()
 {
     return config.breeding;
@@ -190,4 +218,9 @@ uint32_t config_get_tick_delay()
         return 40000;
     }
     return config.tick_delay;
+}
+
+int32_t config_get_overlay_layer()
+{
+    return config.overlay_layer;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -1,3 +1,22 @@
+/*
+    config.h - wl_shimeji's config file parser
+
+    Copyright (C) 2025  CluelessCatBurger <github.com/CluelessCatBurger>
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef CONFIG_PARSER_H
 #define CONFIG_PARSER_H
 
@@ -14,6 +33,7 @@
 #define CONFIG_PARAM_ALLOW_DISMISS_ANIMATIONS_ID 7
 #define CONFIG_PARAM_PER_MASCOT_INTERACTIONS_ID 8
 #define CONFIG_PARAM_TICK_DELAY_ID 9
+#define CONFIG_PARAM_OVERLAY_LAYER 10
 
 struct config {
     bool breeding;
@@ -23,6 +43,7 @@ struct config {
     bool cursor_data;
     bool dismiss_animations;
     bool affordances;
+    int32_t overlay_layer;
 
     uint32_t tick_delay;
 
@@ -44,6 +65,7 @@ bool config_set_ie_throw_policy(int32_t value);
 bool config_set_allow_dismiss_animations(bool value);
 bool config_set_per_mascot_interactions(bool value);
 bool config_set_tick_delay(uint32_t value);
+bool config_set_overlay_layer(int32_t value);
 
 bool config_get_breeding();
 bool config_get_dragging();
@@ -55,5 +77,6 @@ int32_t config_get_ie_throw_policy();
 bool config_get_allow_dismiss_animations();
 bool config_get_per_mascot_interactions();
 uint32_t config_get_tick_delay();
+int32_t config_get_overlay_layer();
 
 #endif

--- a/src/environment.c
+++ b/src/environment.c
@@ -482,7 +482,7 @@ enum environment_init_status dispatch_envs_queue(struct envs_queue* envs)
 {
     for (size_t i = 0; i < envs->envs_count; i++) {
         environment_t* env = envs->envs[i];
-        env->root_surface = layer_surface_create(env->output.output, LAYER_TYPE_OVERLAY);
+        env->root_surface = layer_surface_create(env->output.output, config_get_overlay_layer());
         if (!env->root_surface) {
             WARN("FAILED TO CREATE LAYER SURFACE ON OUTPUT %u aka %s", env->id, env->output.name);
             if (rem_environment) {

--- a/src/environment.h
+++ b/src/environment.h
@@ -74,7 +74,7 @@ enum environment_init_status {
 #include "mascot.h"
 #include "plugins.h"
 
-enum environment_init_status environment_init(int flags, void(*new_listener)(environment_t*), void(*rem_listener)(environment_t*));
+enum environment_init_status environment_init(int flags, void(*new_listener)(environment_t*), void(*rem_listener)(environment_t*), void(*orphaned_mascot)(struct mascot*));
 void environment_dispatch();
 void environment_new_env_listener(void(*listener)(environment_t*));
 void environment_rem_env_listener(void(*listener)(environment_t*));

--- a/src/environment.h
+++ b/src/environment.h
@@ -1,7 +1,7 @@
 /*
     environment.h - wl_shimeji's environment handling
 
-    Copyright (C) 2024  CluelessCatBurger <github.com/CluelessCatBurger>
+    Copyright (C) 2025  CluelessCatBurger <github.com/CluelessCatBurger>
 
     This program is free software; you can redistribute it and/or
     modify it under the terms of the GNU General Public License
@@ -74,7 +74,11 @@ enum environment_init_status {
 #include "mascot.h"
 #include "plugins.h"
 
-enum environment_init_status environment_init(int flags, void(*new_listener)(environment_t*), void(*rem_listener)(environment_t*), void(*orphaned_mascot)(struct mascot*));
+enum environment_init_status environment_init(int flags,
+    void(*new_listener)(environment_t*), void(*rem_listener)(environment_t*),
+    void(*orphaned_mascot)(struct mascot*), void(*mascot_dropped_oob_listener)(struct mascot*, int32_t, int32_t)
+);
+
 void environment_dispatch();
 void environment_new_env_listener(void(*listener)(environment_t*));
 void environment_rem_env_listener(void(*listener)(environment_t*));
@@ -107,6 +111,7 @@ void environment_subsurface_associate_mascot(environment_subsurface_t* surface, 
 struct mascot* environment_subsurface_get_mascot(environment_subsurface_t* surface);
 const struct mascot_pose* environment_subsurface_get_pose(environment_subsurface_t* surface);
 
+// Environment info
 uint32_t environment_screen_width(environment_t* env);
 uint32_t environment_screen_height(environment_t* env);
 uint32_t environment_workarea_width(environment_t* env);
@@ -116,6 +121,11 @@ uint32_t environment_cursor_y(environment_t* env);
 int32_t environment_cursor_dx(environment_t* env);
 int32_t environment_cursor_dy(environment_t* env);
 uint32_t environment_cursor_get_tick_diff(environment_pointer_t* pointer, uint32_t tick);
+uint32_t environment_id(environment_t* env);
+const char* environment_name(environment_t* env);
+const char* environment_desc(environment_t* env);
+bool environment_logical_position(environment_t* env, int32_t* lx, int32_t* ly);
+bool environment_logical_size(environment_t* env, int32_t* lw, int32_t* lh);
 
 // After click on overlay, callback is calling providing absolute click position, and subsurface it was clicked on (if any)
 void environment_select_position(void (*callback)(environment_t* env, int32_t x, int32_t y, environment_subsurface_t* subsurface, void* data), void* data);

--- a/src/layer_surface.c
+++ b/src/layer_surface.c
@@ -1,7 +1,7 @@
 /*
     layer_surface.c - wl_shimeji's overlay functionality
 
-    Copyright (C) 2024  CluelessCatBurger <github.com/CluelessCatBurger>
+    Copyright (C) 2025  CluelessCatBurger <github.com/CluelessCatBurger>
 
     This program is free software; you can redistribute it and/or
     modify it under the terms of the GNU General Public License

--- a/src/layer_surface.c
+++ b/src/layer_surface.c
@@ -67,9 +67,9 @@ static void configure(void* data, struct zwlr_layer_surface_v1* wlr_layer_surfac
 
 static void closed(void* data, struct zwlr_layer_surface_v1* wlr_layer_surface)
 {
-    UNUSED(data);
     UNUSED(wlr_layer_surface);
-    printf("Close called on layer_surface");
+    struct layer_surface* _layer_surface = (struct layer_surface*)data;
+    if (_layer_surface->closed_callback) _layer_surface->closed_callback(_layer_surface->closed_data);
 }
 
 const struct zwlr_layer_surface_v1_listener wlr_shell_surface_listener = {
@@ -184,4 +184,12 @@ void layer_surface_set_dimensions_callback(struct layer_surface* _layer_surface,
 
     _layer_surface->resolution_callback = callback;
     _layer_surface->resolution_data = data;
+}
+
+void layer_surface_set_closed_callback(struct layer_surface* _layer_surface, void (*callback)(void*), void* data)
+{
+    assert(_layer_surface);
+
+    _layer_surface->closed_callback = callback;
+    _layer_surface->closed_data = data;
 }

--- a/src/layer_surface.h
+++ b/src/layer_surface.h
@@ -45,6 +45,9 @@ struct layer_surface
     void (*resolution_callback)(uint32_t, uint32_t, void*);
     void* resolution_data;
 
+    void (*closed_callback)(void*);
+    void* closed_data;
+
     struct zwlr_layer_surface_v1* layer_surface;
 };
 
@@ -59,5 +62,5 @@ void layer_surface_unmap(struct layer_surface* _layer_surface);
 
 void layer_surface_enable_input(struct layer_surface* _layer_surface, bool enable);
 void layer_surface_set_dimensions_callback(struct layer_surface* _layer_surface, void (*callback)(uint32_t, uint32_t, void*), void* data);
-
+void layer_surface_set_closed_callback(struct layer_surface* _layer_surface, void (*callback)(void*), void* data);
 #endif

--- a/src/list.c
+++ b/src/list.c
@@ -1,3 +1,22 @@
+/*
+    list.c - wl_shimeji's lists
+
+    Copyright (C) 2025  CluelessCatBurger <github.com/CluelessCatBurger>
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "list.h"
 
 #include <malloc.h>

--- a/src/list.c
+++ b/src/list.c
@@ -1,0 +1,88 @@
+#include "list.h"
+
+#include <malloc.h>
+#include <stdint.h>
+#include <string.h>
+
+struct list* list_init_(uint32_t capacity)
+{
+    struct list* list = malloc(sizeof(struct list));
+    list->entry_count = capacity;
+    list->entries = calloc(1, sizeof(void*) * capacity);
+    list->entry_used = calloc(1, capacity);
+    return list;
+}
+
+void list_free_(struct list* list)
+{
+    free(list->entries);
+    free(list->entry_used);
+    free(list);
+}
+
+void* list_get_(struct list* list, uint32_t index)
+{
+    if (index >= list->entry_count) {
+        return NULL;
+    }
+    if (!list->entry_used[index]) {
+        return NULL;
+    }
+    return list->entries[index];
+}
+
+uint32_t list_add_(struct list* list, void* entry)
+{
+    if (!entry) {
+        return UINT32_MAX;
+    }
+    if (list->occupied == list->entry_count) {
+        // Grow the list
+        uint32_t new_size = list->entry_count * 2;
+        list->entries = realloc(list->entries, sizeof(void*) * new_size);
+        list->entry_used = realloc(list->entry_used, new_size);
+        memset(list->entry_used + list->entry_count, 0, new_size - list->entry_count);
+        list->entry_count = new_size;
+    }
+    for (uint32_t i = 0; i < list->entry_count; i++) {
+        if (!list->entry_used[i]) {
+            list->entry_used[i] = 1;
+            list->occupied++;
+            list->entries[i] = entry;
+            return i;
+        }
+    }
+    return UINT32_MAX;
+}
+
+void list_remove_(struct list* list, uint32_t index)
+{
+    if (index >= list->entry_count) {
+        return;
+    }
+    if (!list->entry_used[index]) {
+        return;
+    }
+    list->entry_used[index] = 0;
+    list->occupied--;
+}
+
+uint32_t list_find_(struct list* list, void* entry)
+{
+    if (!entry) {
+        return UINT32_MAX;
+    }
+    for (uint32_t i = 0; i < list->entry_count; i++) {
+        if (list->entry_used[i]) {
+            if (list->entries[i] == entry) {
+                return i;
+            }
+        }
+    }
+    return UINT32_MAX;
+}
+
+uint32_t list_count_(struct list* list)
+{
+    return list->occupied;
+}

--- a/src/list.h
+++ b/src/list.h
@@ -1,0 +1,31 @@
+#ifndef LIST_H
+#define LIST_H
+
+#include "master_header.h"
+
+struct list {
+    void **entries;
+    uint32_t entry_count;
+    uint32_t occupied;
+    uint8_t* entry_used;
+    pthread_mutex_t mutex;
+};
+
+#define list_init(capacity) list_init_(capacity);
+#define list_add(list, entry) list_add_((list), (void*)(entry));
+#define list_remove(list, index) list_remove_((list), (index));
+#define list_get(list, index) (list_get_((list), (index)))
+#define list_free(list) list_free_((list))
+#define list_count(list) list_count_((list))
+#define list_size(list) list->entry_count
+#define list_find(list, entry) list_find_((list), (void*)(entry))
+
+struct list* list_init_(uint32_t capacity);
+uint32_t list_add_(struct list* list, void* entry);
+void list_remove_(struct list* list, uint32_t index);
+void* list_get_(struct list* list, uint32_t index);
+void list_free_(struct list* list);
+uint32_t list_count_(struct list* list);
+uint32_t list_find_(struct list* list, void* entry);
+
+#endif

--- a/src/list.h
+++ b/src/list.h
@@ -1,3 +1,22 @@
+/*
+    list.h - wl_shimeji's lists
+
+    Copyright (C) 2025  CluelessCatBurger <github.com/CluelessCatBurger>
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef LIST_H
 #define LIST_H
 

--- a/src/mascot.c
+++ b/src/mascot.c
@@ -71,8 +71,8 @@ struct mascot* mascot_get_target_by_affordance(struct mascot* mascot, const char
                 && strlen(mascot->affordance_manager->slots[i]->current_affordance) == strlen(affordance)
             ) {
                 struct mascot* candidate = mascot->affordance_manager->slots[i];
-
-                if (rand() > RAND_MAX/2) {
+                if (mascot->environment != candidate->environment) continue;
+                if (drand48() > 0.5) {
                     pthread_mutex_unlock(&mascot->affordance_manager->mutex);
                     return candidate;
                 }
@@ -716,7 +716,12 @@ bool mascot_drag_ended(struct mascot* mascot, bool throw)
 // Set the environment of the mascot
 bool mascot_environment_changed(struct mascot* mascot, environment_t* env)
 {
+    INFO("<Mascot:%s:%u> Environment changed", mascot->prototype->name, mascot->id);
     mascot->environment = env;
+    environment_destroy_subsurface(mascot->subsurface);
+    mascot->subsurface = environment_create_subsurface(env);
+    environment_subsurface_associate_mascot(mascot->subsurface, mascot);
+    mascot_reattach_pose(mascot);
     return true;
 }
 

--- a/src/mascot_atlas.c
+++ b/src/mascot_atlas.c
@@ -61,7 +61,7 @@ void _find_ireg(const uint8_t* buffer, uint32_t width, uint32_t height, uint32_t
         *out_height = 0;
     }
 }
-// Function to directly write ARGB pixels and their mirrored version to a file
+
 void _write_memfd(int fd, uint64_t* memfd_pos, const uint8_t* buffer, size_t buffer_len, uint32_t width, uint32_t height) {
     uint8_t* buffers = calloc(2, buffer_len);
 
@@ -74,16 +74,16 @@ void _write_memfd(int fd, uint64_t* memfd_pos, const uint8_t* buffer, size_t buf
             size_t argbIndex = rgbaIndex; // Direct mapping for ARGB buffer
             size_t mirrorIndex = (y * width + (width - 1 - x)) * 4; // Mirrored mapping
 
-            *(buffers+argbIndex) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 2] : 0; // A
-            *(buffers+argbIndex+1) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 1] : 0; // R
-            *(buffers+argbIndex+2) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 0] : 0; // G
-            *(buffers+argbIndex+3) = buffer[rgbaIndex + 3]; // B
+            *(buffers+argbIndex) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 2] : 0; // B
+            *(buffers+argbIndex+1) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 1] : 0; // G
+            *(buffers+argbIndex+2) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 0] : 0; // R
+            *(buffers+argbIndex+3) = buffer[rgbaIndex + 3]; // A
 
             // Fill mirrored ARGB buffer
-            *(buffers+buffer_len+mirrorIndex) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 2] : 0; // A
-            *(buffers+buffer_len+mirrorIndex+1) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 1] : 0; // R
-            *(buffers+buffer_len+mirrorIndex+2) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 0] : 0; // G
-            *(buffers+buffer_len+mirrorIndex+3) = buffer[rgbaIndex + 3]; // B
+            *(buffers+buffer_len+mirrorIndex) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 2] : 0; // B
+            *(buffers+buffer_len+mirrorIndex+1) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 1] : 0; // G
+            *(buffers+buffer_len+mirrorIndex+2) = buffer[rgbaIndex + 3] ? buffer[rgbaIndex + 0] : 0; // R
+            *(buffers+buffer_len+mirrorIndex+3) = buffer[rgbaIndex + 3]; // A
         }
     }
 

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1,3 +1,22 @@
+/*
+    plugin.c - wl_shimeji's plugin support
+
+    Copyright (C) 2025  CluelessCatBurger <github.com/CluelessCatBurger>
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
+*/
+
 #include "plugins.h"
 #include "environment.h"
 

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -1,3 +1,22 @@
+/*
+    plugin.h - wl_shimeji's plugin support
+
+    Copyright (C) 2025  CluelessCatBurger <github.com/CluelessCatBurger>
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
+*/
+
 #ifndef PLUGINS_H
 #define PLUGINS_H
 

--- a/src/shimeji-overlay.c
+++ b/src/shimeji-overlay.c
@@ -17,7 +17,6 @@
     along with this program; if not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "layer_surface.h"
 #define _GNU_SOURCE
 #include <bits/types/sigset_t.h>
 #include <sys/mman.h>
@@ -41,6 +40,7 @@
 #include <string.h>
 #include "plugins.h"
 #include "config.h"
+#include "layer_surface.h"
 
 #define MASCOT_OVERLAYD_INSTANCE_EXISTS -1
 #define MASCOT_OVERLAYD_INSTANCE_CREATE_ERROR -2

--- a/src/shimeji-overlay.c
+++ b/src/shimeji-overlay.c
@@ -17,6 +17,7 @@
     along with this program; if not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "layer_surface.h"
 #define _GNU_SOURCE
 #include <bits/types/sigset_t.h>
 #include <sys/mman.h>
@@ -1272,6 +1273,7 @@ int main(int argc, const char** argv)
         config_set_allow_dismiss_animations(true);
         config_set_per_mascot_interactions(true);
         config_set_tick_delay(40000);
+        config_set_overlay_layer(LAYER_TYPE_OVERLAY);
         config_write(config_file_path);
     }
 

--- a/src/wayland_includes.h
+++ b/src/wayland_includes.h
@@ -6,3 +6,4 @@
 #include <wayland-protocols/fractional-scale-v1.h>
 #include <wayland-protocols/cursor-shape-v1.h>
 #include <wayland-protocols/viewporter.h>
+#include <wayland-protocols/xdg-output.h>


### PR DESCRIPTION
Closes #11 

Current progress:
- [x] Fixed crashes caused by hot plugging/unplugging
- [x] When a monitor is unplugged, mascots now move to another output
- [x] shimejictl summon (without --select) can now spawn mascots on any output, not just the first one
- [x] Add support for moving mascots between outputs
