### PR TITLE
Fix a segmentation fault in mascot_action_get_next

### DIFF
--- a/src/mascot.c
+++ b/src/mascot.c
@@ -509,8 +509,6 @@ static enum mascot_tick_result mascot_action_get_next(struct mascot *mascot,
       } else {
         next_func = state_funcs[actionref.action->type].next;
       }
-    } else {
-      return mascot_action_get_next(mascot, tick);
     }
 
     if (!next_func) {


### PR DESCRIPTION
Closes #49 

Remove recursion, so that it runs the if statement immediately below instead, which handles when `next_func` is `NULL` by returning `mascot_tick_next`.